### PR TITLE
Another route has already been assigned name [env-editor.key]

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -12,8 +12,8 @@ Route::prefix(config($package.'.route.prefix'))
         Route::get('/', $controllerName.'@index')->name($routeMainName.'.index');
 
         Route::post('key', $controllerName.'@addKey')->name($routeMainName.'.key');
-        Route::patch('key', $controllerName.'@editKey')->name($routeMainName.'.key');
-        Route::delete('key', $controllerName.'@deleteKey')->name($routeMainName.'.key');
+        Route::patch('key', $controllerName.'@editKey');
+        Route::delete('key', $controllerName.'@deleteKey');
 
         Route::prefix('files')->group(function () use ($package, $routeMainName, $controllerName) {
             Route::get('/', $controllerName.'@getBackupFiles')

--- a/src/routes.php
+++ b/src/routes.php
@@ -8,14 +8,14 @@ $controllerName = 'GeoSot\EnvEditor\Controllers\\EnvController';
 
 Route::prefix(config($package.'.route.prefix'))
     ->middleware(config($package.'.route.middleware'))
-    ->group(function () use ($package, $routeMainName, $controllerName) {
+    ->group(function () use ($routeMainName, $controllerName) {
         Route::get('/', $controllerName.'@index')->name($routeMainName.'.index');
 
         Route::post('key', $controllerName.'@addKey')->name($routeMainName.'.key');
         Route::patch('key', $controllerName.'@editKey');
         Route::delete('key', $controllerName.'@deleteKey');
 
-        Route::prefix('files')->group(function () use ($package, $routeMainName, $controllerName) {
+        Route::prefix('files')->group(function () use ($routeMainName, $controllerName) {
             Route::get('/', $controllerName.'@getBackupFiles')
                 ->name($routeMainName.'.getBackups');
             Route::post('create-backup', $controllerName.'@createBackup')


### PR DESCRIPTION
It is not possible to define multiple route names, because we cannot cache the route

![image](https://user-images.githubusercontent.com/9611224/92049881-9659da80-edc6-11ea-8d6d-a62e05a3104e.png)
