### PR TITLE
Change returned HTTP METHOD Names to Uppercase

### DIFF
--- a/resources/views/components/_itemModal.blade.php
+++ b/resources/views/components/_itemModal.blade.php
@@ -109,11 +109,11 @@
                 getAjaxMethod() {
                     switch (this.type) {
                         case 'delete':
-                            return 'delete';
+                            return 'DELETE';
                         case 'edit':
-                            return 'patch';
+                            return 'PATCH';
                         default:
-                            return 'post'
+                            return 'POST'
                     }
                 },
                 makeReadOnly(arg = null) {


### PR DESCRIPTION
The returned method names fail to work with nginx installations, changing the method names to uppercase fixes the issue.




closes #28