### PR TITLE
✨ Feature - Auto `.env` file-name detection

### DIFF
--- a/config/env-editor.php
+++ b/config/env-editor.php
@@ -12,7 +12,8 @@ return [
         //backup files directory
         'backupDirectory' => storage_path('env-editor'),
     ],
-    // .env file name
+
+    // .env file name, use '' (empty string) to auto-detect currently used .env
     'envFileName' => '.env',
 
     /*

--- a/src/Helpers/EnvFilesManager.php
+++ b/src/Helpers/EnvFilesManager.php
@@ -157,7 +157,10 @@ class EnvFilesManager
         $envFileName = $this->envEditor->config('envFileName');
 
         // Attempt to auto-detect the currently used .env file, if provided config has been left blank
-        if ($envFileName === '') { $envFileName = app()->environmentFile(); }
+        if ($envFileName === '') {
+            $envFileName = app()->environmentFile();
+        }
+
         return $envFileName;
     }
 

--- a/src/Helpers/EnvFilesManager.php
+++ b/src/Helpers/EnvFilesManager.php
@@ -153,7 +153,12 @@ class EnvFilesManager
      */
     protected function getEnvFileName(): string
     {
-        return $this->envEditor->config('envFileName');
+        // Attempt to fetch the used .env file from 'config/env-editor'
+        $envFileName = $this->envEditor->config('envFileName');
+
+        // Attempt to auto-detect the currently used .env file, if provided config has been left blank
+        if ($envFileName === '') { $envFileName = app()->environmentFile(); }
+        return $envFileName;
     }
 
     /**


### PR DESCRIPTION
Closes #34

## Description
Gives the option to configure the `envFileName` as `''` *(empty string)* to auto-detect currently used `.env`